### PR TITLE
stage makefile and workflow updates

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -1,0 +1,20 @@
+### This is the Terraform-generated stage-build.yml workflow for the ppod-stage repository ###
+name: Stage Build and Deploy Lambda Container
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  deploy:
+    name: Stage Deploy Lambda Container
+    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy-stage.yml@container-flows
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE: "ppod-gha-stage"
+      ECR: "ppod-stage"
+      FUNCTION: "ppod-stage"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ ECR_NAME_DEV:=ppod-dev
 ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/ppod-dev
 FUNCTION_DEV:=ppod-dev
 ### End of Terraform-generated header ###
+### This is the Terraform-generated Makefile header for ppod-stage
+ECR_NAME_STAGE:=ppod-stage
+ECR_URL_STAGE:=840055183494.dkr.ecr.us-east-1.amazonaws.com/ppod-stage
+FUNCTION_STAGE:=ppod-stage
+### End of Terraform-generated header ###
 
 help: ## Print this message
 	@awk 'BEGIN { FS = ":.*##"; print "Usage:  make <target>\n\nTargets:" } \
@@ -61,3 +66,20 @@ update-lambda-dev: ## Updates the lambda with whatever is the most recent image 
 	aws lambda update-function-code \
 		--function-name $(FUNCTION_DEV) \
 		--image-uri $(ECR_URL_DEV):latest
+
+### Terraform-generated Makefile developer Deploy Commands ###
+dist-stage: ## Build docker container (intended for developer-based manual build)
+	docker build --platform linux/amd64 \
+	    -t $(ECR_URL_STAGE):latest \
+		-t $(ECR_URL_STAGE):`git describe --always` \
+		-t $(ECR_NAME_STAGE):latest .
+
+publish-stage: dist-stage ## Build, tag and push (intended for developer-based manual publish)
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_STAGE)
+	docker push $(ECR_URL_STAGE):latest
+	docker push $(ECR_URL_STAGE):`git describe --always`
+
+update-lambda-stage: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
+	aws lambda update-function-code \
+		--function-name $(FUNCTION_STAGE) \
+		--image-uri $(ECR_URL_STAGE):latest


### PR DESCRIPTION
# Subject
Sets up the stage workflow and updates the makefile with stage specific commands

# Why these changes are being introduced:
Stage has been deployed, so we need stage workflow and makefile commands

# How this addresses that need:
This is a copy/paste from the infrastructure outputs for stage.

# Side effects of this change:
None

# Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ENSY-87